### PR TITLE
Extracted Logger class from Receiver, and added some APIs (keeping backward compatibility)

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -13,7 +13,9 @@ void ofApp::setup(){
 	w = 100.0;
 	h = 100.0;
 
+	// setup receiver
 	osc_receiver.setup(7777, [&](const ofxOscMessage& msg) {
+		// filter OSC
 		ofxSimpleOsc::filter(msg)
 			.when("/test", [&]() {
 				ofLog() << "test OSC received!";
@@ -28,9 +30,17 @@ void ofApp::setup(){
 			.when("/test3", [&](const ofxOscMessage& m) {
 				ofLog() << "test3 (" << m.getArgAsString(0) << ")";
 			})
-			.else_show_warning();
+			.else_show_warning(); // Show not handled warning
 
-		//// You can also simply use ofxOscMessage
+			// .else_([&](const ofxOscMessage& m){
+			//      // If you want to write code at end of method chain,
+			//      // please add .else_() instead of .else_show_warning()
+			//
+			//      // To warn, in this block, you can use
+			//	    // osc_receiver.showNotHandledWarning();
+			// })
+
+		// NOTE: You can also simply use ofxOscMessage, without using Filter
 		//
 		// if (msg.getAddress() == "/test") {
 		//	 ofLog() << "test OSC received!";
@@ -38,9 +48,17 @@ void ofApp::setup(){
 		// else {
 		//	 osc_receiver.showNotHandledWarning();
 		// }
+
+		// NOTE: And if you want, you can move above codes into
+		//       `void ofApp::onOscMessage(const ofxOscMessage& msg)` or so on
+		//
+		// ofApp::onOscMessage(msg);
+		//
+
 	});
 
-	//// ofxSimpleOsc simply print logs of received OSC messages. if you don't need them, you can disable:
+	// NOTE: ofxSimpleOsc prints logs of every received OSC messages.
+	//       if you don't need them, you can disable:
 	//
 	// osc_receiver.setOscLogEnabled(false);
 

--- a/src/Filter.h
+++ b/src/Filter.h
@@ -325,10 +325,10 @@ namespace ofxSimpleOsc {
 			matched = true;
 		}
 
-		void else_show_warning(){
+		void else_show_warning(const string& module_name = "ofxSimpleOsc::Filter"){
 			if (matched) { return; }
 
-			ofLogWarning("ofxSimpleOsc::Filter") << m.getAddress() << " (typetag: " << m.getTypeString() << ") not match. ignored.";
+			ofLogWarning(module_name) << m.getAddress() << " (typetag: " << m.getTypeString() << ") not match. ignored.";
 		}
 	};
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "ofxOsc.h"
+#include <string>
+#include <cctype>
+
+namespace ofxSimpleOsc {
+
+	class Logger {
+	public:
+		std::string toString(const ofxOscMessage & m, bool print_args)
+		{
+			std::stringstream ss;
+
+			ss << m.getAddress();
+
+			int num_args = m.getNumArgs();
+			for (int i = 0; i < num_args; ++i) {
+				auto v = getOscArg(m, i);
+				ss << " " + v;
+			}
+
+			ss << "";
+
+			return std::move(ss.str());
+		}
+
+		void log(const ofxOscMessage & m, bool print_args, const std::string& log_module = "ofxSimpleOsc::Logger")
+		{
+			std::string s = toString(m, print_args);
+			ofLogNotice(log_module) << s;
+		}
+
+	private:
+		std::string getOscArg(const ofxOscMessage& m, size_t i)
+		{
+			auto type = m.getArgType(i);
+
+			switch (type) {
+			case OFXOSC_TYPE_FLOAT:
+				return ofToString(m.getArgAsFloat(i), 3);
+			case OFXOSC_TYPE_INT32:
+				return ofToString(m.getArgAsInt32(i));
+			case OFXOSC_TYPE_INT64:
+				return ofToString(m.getArgAsInt64(i));
+			case OFXOSC_TYPE_DOUBLE:
+				return ofToString(m.getArgAsDouble(i), 3);
+			case OFXOSC_TYPE_TRUE:
+				return "true";
+			case OFXOSC_TYPE_FALSE:
+				return "false";
+			case OFXOSC_TYPE_CHAR:
+			{
+				char c = m.getArgAsChar(i);
+				std::string s(1, c);
+				return s;
+			}
+			case OFXOSC_TYPE_STRING:
+				return m.getArgAsString(i);
+			default:
+			{
+				auto loglevel = ofGetLogLevel();
+				ofSetLogLevel(ofLogLevel::OF_LOG_SILENT);
+				std::string s = m.getArgAsString(i);
+				ofSetLogLevel(loglevel);
+				return s;
+			}
+			}
+		}
+
+		bool is_int(const std::string & s)
+		{
+			return !s.empty() && std::find_if(s.begin(),
+				s.end(), [](char c) { return !std::isdigit(c); }) == s.end();
+		}
+
+		bool is_float(const std::string & s)
+		{
+			std::string::const_iterator it = s.begin();
+			bool decimalPoint = false;
+			int minSize = 0;
+			if (s.size() > 0 && (s[0] == '-' || s[0] == '+')) {
+				it++;
+				minSize++;
+			}
+			while (it != s.end()) {
+				if (*it == '.') {
+					if (!decimalPoint) decimalPoint = true;
+					else break;
+				}
+				else if (!std::isdigit(*it) && ((*it != 'f') || it + 1 != s.end() || !decimalPoint)) {
+					break;
+				}
+				++it;
+			}
+			return s.size() > minSize && it == s.end();
+		}
+
+		bool is_double(const std::string & s)
+		{
+			return is_type<double>(s);
+		}
+
+		template<typename T>
+		bool is_type(const std::string & s)
+		{
+			T target;
+			stringstream ss;
+			ss << s;
+			ss >> target;
+			return ss.good();
+		}
+
+		std::vector<std::string> split(const std::string& s, char delimiter)
+		{
+			std::vector<std::string> tokens;
+			std::string token;
+			std::istringstream tokenStream(s);
+			while (std::getline(tokenStream, token, delimiter))
+			{
+				tokens.push_back(token);
+			}
+			return tokens;
+		}
+
+	};
+
+	static Logger logger = Logger();
+}

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -1,11 +1,12 @@
 #include "Receiver.h"
 
 #include "ofMain.h"
+#include "Logger.h"
 
 using namespace std;
 using namespace ofxSimpleOsc;
 
-void Receiver::update(ofEventArgs & args)
+void ofxSimpleOsc::Receiver::update(ofEventArgs & args)
 {
 	while (receiver.hasWaitingMessages()) {
 		ofxOscMessage m;
@@ -14,7 +15,7 @@ void Receiver::update(ofEventArgs & args)
 		string addr = m.getAddress();
 
 		if (enable_log) {
-			printOscLog(m);
+			printOsclog(m, print_args, logger_module_name);
 		}
 
 		ofNotifyEvent(ofxSimpleOsc::OSC_MESSAGE_RECEIVED, m);
@@ -25,10 +26,10 @@ void Receiver::update(ofEventArgs & args)
 	}
 }
 
-void Receiver::setup(int port, bool _enable_log, std::function<void(const ofxOscMessage&)> receive_func)
+void ofxSimpleOsc::Receiver::setup(int port, bool _enable_log, std::function<void(const ofxOscMessage&)> receive_func)
 {
 	enable_log = _enable_log;
-	if(!receiver.isListening()) {
+	if (!receiver.isListening()) {
 		ofAddListener(ofEvents().update, this, &Receiver::update);
 	}
 	receiver.setup(port);
@@ -40,126 +41,29 @@ void ofxSimpleOsc::Receiver::setup(int port, std::function<void(const ofxOscMess
 	setup(port, true, receive_func);
 }
 
-void ofxSimpleOsc::Receiver::showNotHandledWarning()
+void ofxSimpleOsc::Receiver::showNotHandledWarning(const std::string& module_name)
 {
-	ofLogWarning("ofxSimpleOsc::Receiver") << "not handled (ignored.)";
+	ofLogWarning(module_name) << "not handled. ignored.";
 }
 
-void ofxSimpleOsc::Receiver::printOscLog(const ofxOscMessage & m, bool print_args)
+void ofxSimpleOsc::Receiver::showNotHandledWarning(const ofxOscMessage& m, const std::string& module_name)
 {
-	stringstream ss;
-
-	ss << m.getAddress();
-
-	int num_args = m.getNumArgs();
-	for (int i = 0; i < num_args; ++i) {
-		auto v = getOscArg(m, i);
-		ss << " " + v;
-	}
-
-	ss << "";
-
-	string s = ss.str();
-	ofLogNotice("ofxSimpleOsc::Receiver") << s;
+	ofLogWarning(module_name) << m.getAddress() << " (typetag: " << m.getTypeString() << ") not handled. ignored.";
 }
 
-void ofxSimpleOsc::Receiver::setOscLogEnabled(bool b)
+void ofxSimpleOsc::Receiver::printOsclog(const ofxOscMessage & m, bool print_args, const std::string& module_name)
 {
-	enable_log = b;
+	ofxSimpleOsc::logger.log(m, print_args, module_name);
+}
+
+void ofxSimpleOsc::Receiver::setOscLogEnabled(bool _enable_log, bool _print_args, const std::string & _logger_module_name)
+{
+	enable_log = _enable_log;
+	print_args = _print_args;
+	logger_module_name = _logger_module_name;
 }
 
 bool ofxSimpleOsc::Receiver::getOscLogEnabled()
 {
 	return enable_log;
-}
-
-std::string Receiver::getOscArg(const ofxOscMessage& m, size_t i)
-{
-	auto type = m.getArgType(i);
-
-	switch (type) {
-	case OFXOSC_TYPE_FLOAT:
-		return ofToString(m.getArgAsFloat(i), 3);
-	case OFXOSC_TYPE_INT32:
-		return ofToString(m.getArgAsInt32(i));
-	case OFXOSC_TYPE_INT64:
-		return ofToString(m.getArgAsInt64(i));
-	case OFXOSC_TYPE_DOUBLE:
-		return ofToString(m.getArgAsDouble(i), 3);
-	case OFXOSC_TYPE_TRUE:
-		return "true";
-	case OFXOSC_TYPE_FALSE:
-		return "false";
-	case OFXOSC_TYPE_CHAR:
-	{
-		char c = m.getArgAsChar(i);
-		string s(1, c);
-		return s;
-	}
-	case OFXOSC_TYPE_STRING:
-		return m.getArgAsString(i);
-	default:
-	{
-		auto loglevel = ofGetLogLevel();
-		ofSetLogLevel(ofLogLevel::OF_LOG_SILENT);
-		string s = m.getArgAsString(i);
-		ofSetLogLevel(loglevel);
-		return s;
-	}
-	}
-}
-
-bool Receiver::is_int(const std::string & s)
-{
-	return !s.empty() && std::find_if(s.begin(),
-		s.end(), [](char c) { return !std::isdigit(c); }) == s.end();
-}
-
-bool Receiver::is_float(const std::string & s)
-{
-	std::string::const_iterator it = s.begin();
-	bool decimalPoint = false;
-	int minSize = 0;
-	if (s.size() > 0 && (s[0] == '-' || s[0] == '+')) {
-		it++;
-		minSize++;
-	}
-	while (it != s.end()) {
-		if (*it == '.') {
-			if (!decimalPoint) decimalPoint = true;
-			else break;
-		}
-		else if (!std::isdigit(*it) && ((*it != 'f') || it + 1 != s.end() || !decimalPoint)) {
-			break;
-		}
-		++it;
-	}
-	return s.size() > minSize && it == s.end();
-}
-
-bool Receiver::is_double(const std::string & s)
-{
-	return is_type<double>(s);
-}
-
-template<typename T>
-bool Receiver::is_type(const std::string & s)
-{
-	T target;
-	stringstream ss;
-	ss << s;
-	ss >> target;
-	return ss.good();
-}
-
-std::vector<std::string> Receiver::split(const std::string& s, char delimiter)
-{
-	std::vector<std::string> tokens;
-	std::string token;
-	std::istringstream tokenStream(s);
-	while (std::getline(tokenStream, token, delimiter))
-	{
-		tokens.push_back(token);
-	}
-	return tokens;
 }

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -56,6 +56,11 @@ void ofxSimpleOsc::Receiver::printOsclog(const ofxOscMessage & m, bool print_arg
 	ofxSimpleOsc::logger.log(m, print_args, module_name);
 }
 
+void ofxSimpleOsc::Receiver::setOscLogEnabled(bool enabled)
+{
+	enable_log = enabled;
+}
+
 void ofxSimpleOsc::Receiver::setOscLogEnabled(bool _enable_log, bool _print_args, const std::string & _logger_module_name)
 {
 	enable_log = _enable_log;

--- a/src/Receiver.h
+++ b/src/Receiver.h
@@ -13,21 +13,12 @@ namespace ofxSimpleOsc {
 
 	protected:
 		bool enable_log = true;
+		bool print_args = true;
+		std::string logger_module_name = "ofxSimpleOsc::Receiver";
 		ofxOscReceiver receiver;
 		std::function<void(const ofxOscMessage&)> receive_func;
 
 		void update(ofEventArgs & args);
-
-		bool is_int(const std::string& s);
-		bool is_float(const std::string& s);
-		bool is_double(const std::string& s);
-
-		template<typename T>
-		bool is_type(const std::string& s);
-
-		std::vector<std::string> split(const std::string& s, char delimiter);
-
-		std::string getOscArg(const ofxOscMessage& m, size_t i);
 
 	public:
 		Receiver() {}
@@ -39,11 +30,10 @@ namespace ofxSimpleOsc {
 		}
 		void setup(int port, bool enable_osc_log, std::function<void(const ofxOscMessage&)> receive_func);
 		void setup(int port, std::function<void(const ofxOscMessage&)> receive_func);
-
-		void showNotHandledWarning();
-		void printOscLog(const ofxOscMessage& m, bool print_args=true);
-
-		void setOscLogEnabled(bool b);
+		void showNotHandledWarning(const std::string& module_name="ofxSimpleOsc::Receiver");
+		void showNotHandledWarning(const ofxOscMessage& m, const std::string& module_name="ofxSimpleOsc::Receiver");
+		void printOsclog(const ofxOscMessage & m, bool print_args=true, const std::string& module_name="ofxSimpleOsc::Receiver");
+		void setOscLogEnabled(bool enabled, bool print_args=true, const std::string& logger_module_name="ofxSimpleOsc::Receiver");
 		bool getOscLogEnabled();
 	};
 

--- a/src/Receiver.h
+++ b/src/Receiver.h
@@ -33,7 +33,8 @@ namespace ofxSimpleOsc {
 		void showNotHandledWarning(const std::string& module_name="ofxSimpleOsc::Receiver");
 		void showNotHandledWarning(const ofxOscMessage& m, const std::string& module_name="ofxSimpleOsc::Receiver");
 		void printOsclog(const ofxOscMessage & m, bool print_args=true, const std::string& module_name="ofxSimpleOsc::Receiver");
-		void setOscLogEnabled(bool enabled, bool print_args=true, const std::string& logger_module_name="ofxSimpleOsc::Receiver");
+		void setOscLogEnabled(bool enabled);
+		void setOscLogEnabled(bool enabled, bool print_args, const std::string& logger_module_name="ofxSimpleOsc::Receiver");
 		bool getOscLogEnabled();
 	};
 

--- a/src/Sender.h
+++ b/src/Sender.h
@@ -4,15 +4,25 @@
 #include "ofxOsc.h"
 #include "ofMain.h"
 
+#include "Logger.h"
+
 namespace ofxSimpleOsc {
 	class Sender {
 	protected:
 		ofxOscSender sender;
 		ofxOscMessage temp_message;
 
+		bool print_log = false;
+		bool log_with_args = true;
+		std::string logger_module_name = "ofxSimpleOsc::Sender";
+
 		void sendImpl(ofxOscMessage& message)
 		{
 			sender.sendMessage(message);
+
+			if (print_log) {
+				ofxSimpleOsc::logger.log(temp_message, log_with_args, logger_module_name);
+			}
 		}
 
 		template<class Head, class ...Tail>
@@ -141,6 +151,10 @@ namespace ofxSimpleOsc {
 		void send(ofxOscMessage & message, bool wrap_in_bundle)
 		{
 			sender.sendMessage(message, wrap_in_bundle);
+
+			if (print_log) {
+				ofxSimpleOsc::logger.log(temp_message, log_with_args, logger_module_name);
+			}
 		}
 
 		template<class ...Args>
@@ -165,7 +179,25 @@ namespace ofxSimpleOsc {
 		{
 			temp_message.clear();
 			temp_message.setAddress(address);
-			sender.sendMessage(temp_message);
+
+			sendImpl(temp_message);
+		}
+
+		void setOscLogEnabled(bool _enable_log)
+		{
+			print_log = _enable_log;
+		}
+
+		void setOscLogEnabled(bool _enable_log, bool _print_args, const std::string & _logger_module_name="ofxSimpleOsc::Sender")
+		{
+			print_log = _enable_log;
+			log_with_args = _print_args;
+			logger_module_name = _logger_module_name;
+		}
+
+		bool getOscLogEnabled()
+		{
+			return print_log;
 		}
 	};
 };

--- a/src/ofxSimpleOsc.h
+++ b/src/ofxSimpleOsc.h
@@ -3,3 +3,4 @@
 #include "Receiver.h"
 #include "Sender.h"
 #include "Filter.h"
+#include "Logger.h"


### PR DESCRIPTION
- Extracted Logger class from Receiver
- Refactored `Receiver#printOscLogs` to use `Logger#log()`
- Added `Receiver#setOscLogEnabled(bool enabled, bool print_args, const std::string& logger_module_name);` in order to set more detailed logger feature.
- Added logging feature to Sender class (to keep backward compatibility, it is disabled as default)
- Added `Sender#setOscLogEnabled()` and `Sender#getOscLogEnabled()`, same as Receiver
